### PR TITLE
Feat: ETF 테마 및 카테고리별 종목 조회 API 구현 (#22)

### DIFF
--- a/app/api/etf/category/[categoryId]/route.ts
+++ b/app/api/etf/category/[categoryId]/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+// export async function GET(req: NextRequest) {
+//   const url = new URL(req.url);
+//   const pathnameParts = url.pathname.split("/");
+
+//   return NextResponse.json();
+// }

--- a/app/api/etf/category/[categoryId]/route.ts
+++ b/app/api/etf/category/[categoryId]/route.ts
@@ -1,9 +1,115 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 
-// export async function GET(req: NextRequest) {
-//   const url = new URL(req.url);
-//   const pathnameParts = url.pathname.split("/");
+export async function GET(req: NextRequest) {
+  try {
+    const url = new URL(req.url);
+    const pathnameParts = url.pathname.split('/');
+    const etfCategoryId = pathnameParts[pathnameParts.length - 1];
 
-//   return NextResponse.json();
-// }
+    const page = Number(url.searchParams.get('page') ?? '1');
+    const size = Number(url.searchParams.get('size') ?? '20');
+    const keyword = url.searchParams.get('keyword')?.trim().toLowerCase() ?? '';
+    const filter = url.searchParams.get('filter') ?? 'name'; // name | code
+
+    if (!etfCategoryId || isNaN(Number(etfCategoryId))) {
+      return NextResponse.json(
+        { error: 'Invalid or missing etfCategoryId' },
+        { status: 400 }
+      );
+    }
+
+    // 카테고리 정보 조회
+    const category = await prisma.etfCategory.findUnique({
+      where: { id: Number(etfCategoryId) },
+      select: { fullPath: true },
+    });
+
+    if (!category) {
+      return NextResponse.json(
+        { error: 'Category not found' },
+        { status: 404 }
+      );
+    }
+
+    const where = {
+      etfCategoryId: Number(etfCategoryId),
+      ...(keyword &&
+        filter === 'name' && {
+          issueName: { contains: keyword },
+        }),
+      ...(keyword &&
+        filter === 'code' && {
+          issueCode: { contains: keyword },
+        }),
+    };
+
+    const [etfs, total] = await Promise.all([
+      prisma.etf.findMany({
+        where,
+        skip: (page - 1) * size,
+        take: size,
+        orderBy: { id: 'asc' },
+        select: {
+          issueCode: true,
+          issueName: true,
+          tradings: {
+            orderBy: { baseDate: 'desc' },
+            take: 1,
+            select: {
+              accTradeVolume: true,
+              tddClosePrice: true,
+              flucRate: true,
+            },
+          },
+        },
+      }),
+      prisma.etf.count({ where }),
+    ]);
+
+    /*
+    // etfCategoryId에 속한 ETF 목록 가져오기
+    const etfs = await prisma.etf.findMany({
+      where: { etfCategoryId: Number(etfCategoryId) },
+      select: {
+        id: true,
+        issueCode: true,
+        issueName: true,
+        tradings: {
+          orderBy: { baseDate: 'desc' },
+          take: 1, // 가장 최신 거래 데이터 1건
+          select: {
+            accTradeVolume: true,
+            tddClosePrice: true,
+            flucRate: true,
+          }
+        }
+      }
+    });
+    */
+
+    // 응답 구조 가공
+    const data = etfs.map((etf) => ({
+      issueCode: etf.issueCode,
+      issueName: etf.issueName,
+      accTradeVolume: etf.tradings[0]?.accTradeVolume
+        ? Number(etf.tradings[0]?.accTradeVolume)
+        : null,
+      tddClosePrice: etf.tradings[0]?.tddClosePrice ?? null,
+      flucRate: etf.tradings[0]?.flucRate ?? null,
+    }));
+
+    // 카테고리 테마 보여주기 위해 fullPath 반환, - 기준으로 가장 끝 요소 추출해서 사용
+    return NextResponse.json({
+      data,
+      total,
+      etfCategoryFullPath: category.fullPath,
+    });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'Internal Server Error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/etf/theme/[themeSlug]/route.ts
+++ b/app/api/etf/theme/[themeSlug]/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+const themeToCategoryIds: Record<string, number[]> = {
+  'market-core': [1],
+  industry: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+  strategy: [15, 16, 17, 18, 19, 20, 21, 22],
+  'market-cap': [23, 24],
+  'mixed-assets': [25, 26],
+};
+
+const themeToDisplayName: Record<string, string> = {
+  'market-core': '주식-시장대표',
+  industry: '주식-업종섹터',
+  strategy: '주식-전략',
+  'market-cap': '주식-규모',
+  'mixed-assets': '혼합자산',
+};
+
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const pathnameParts = url.pathname.split('/');
+  const themeSlug = pathnameParts[pathnameParts.length - 1];
+  const ids = themeToCategoryIds[themeSlug];
+  const displayName = themeToDisplayName[themeSlug];
+
+  if (!ids) {
+    return NextResponse.json({ error: 'Invalid themeSlug' }, { status: 400 });
+  }
+
+  const categories = await prisma.etfCategory.findMany({
+    where: { id: { in: ids } },
+    select: {
+      id: true,
+      assetType: true,
+      assetSubtype: true,
+      fullPath: true,
+    },
+    orderBy: { id: 'asc' },
+  });
+
+  const renamed = categories.map((c) => {
+    const isMixedAssets = themeSlug === 'mixed-assets';
+    const rawName = isMixedAssets ? c.assetType : c.assetSubtype;
+
+    return {
+      id: c.id,
+      name: rawName ?? 'etc',
+      fullname: c.fullPath,
+    };
+  });
+
+  // etc를 맨 뒤로 정렬
+  renamed.sort((a, b) => {
+    if (a.name === 'etc' && b.name !== 'etc') return 1;
+    if (a.name !== 'etc' && b.name === 'etc') return -1;
+    return 0;
+  });
+
+  return NextResponse.json({
+    displayName,
+    categories: renamed,
+  });
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,25 +92,25 @@ model EtfPdf {
 model EtfDailyTrading {
   id                  Int      @id @default(autoincrement())
   etfId               Int      @map("etf_id")
-  baseDate            DateTime @map("base_date")
-  issueCode           String   @map("issue_code")
-  issueName           String?  @map("issue_name")
-  cmpPrevddPrice      Decimal? @map("cmp_prevdd_price") @db.Decimal(10, 2)
-  flucRate            Decimal? @map("fluc_rate") @db.Decimal(5, 2)
-  tddClosePrice       Decimal? @map("tdd_close_price") @db.Decimal(10, 2)
-  nav                 Decimal? @db.Decimal(10, 2)
-  tddOpenPrice        Decimal? @map("tdd_open_price") @db.Decimal(10, 2)
-  tddHighPrice        Decimal? @map("tdd_high_price") @db.Decimal(10, 2)
-  tddLowPrice         Decimal? @map("tdd_low_price") @db.Decimal(10, 2)
-  accTradeVolume      BigInt?  @map("acc_trade_volume")
-  accTotalValue       BigInt?  @map("acc_total_value")
-  marketCap           BigInt?  @map("market_cap")
-  netAssetTotalAmount BigInt?  @map("net_asset_total_amount")
-  listShrs            BigInt?  @map("list_shrs")
-  idxIndNm            String?  @map("idx_ind_nm")
-  objStkprcIdx        Decimal? @map("obj_stkprc_idx") @db.Decimal(10, 2)
-  cmpprevddIdx        Decimal? @map("cmpprevdd_idx") @db.Decimal(10, 2)
-  flucRtIdx           Decimal? @map("fluc_rt_idx") @db.Decimal(5, 2)
+  baseDate            DateTime @map("base_date") // 기준일자
+  issueCode           String   @map("issue_code") // 종목코드
+  issueName           String?  @map("issue_name") // 종목명
+  cmpPrevddPrice      Decimal? @map("cmp_prevdd_price") @db.Decimal(10, 2) // 대비
+  flucRate            Decimal? @map("fluc_rate") @db.Decimal(5, 2) // 등락률
+  tddClosePrice       Decimal? @map("tdd_close_price") @db.Decimal(10, 2) //종가
+  nav                 Decimal? @db.Decimal(10, 2) // 순자산가치
+  tddOpenPrice        Decimal? @map("tdd_open_price") @db.Decimal(10, 2) // 시가
+  tddHighPrice        Decimal? @map("tdd_high_price") @db.Decimal(10, 2) // 고가
+  tddLowPrice         Decimal? @map("tdd_low_price") @db.Decimal(10, 2) // 저가
+  accTradeVolume      BigInt?  @map("acc_trade_volume") // 거래량
+  accTotalValue       BigInt?  @map("acc_total_value") // 거래대금
+  marketCap           BigInt?  @map("market_cap") // 시가총액
+  netAssetTotalAmount BigInt?  @map("net_asset_total_amount") // 순자산총액
+  listShrs            BigInt?  @map("list_shrs") // 상장좌수
+  idxIndNm            String?  @map("idx_ind_nm") // 기초지수_지수명
+  objStkprcIdx        Decimal? @map("obj_stkprc_idx") @db.Decimal(10, 2) // 기초지수_종가
+  cmpprevddIdx        Decimal? @map("cmpprevdd_idx") @db.Decimal(10, 2) // 기초지수_대비
+  flucRtIdx           Decimal? @map("fluc_rt_idx") @db.Decimal(5, 2) // 기초지수_등락률
 
   etf Etf @relation(fields: [etfId], references: [id])
 


### PR DESCRIPTION
## 📌 연관된 이슈 번호

- closes #22 

## 🌱 주요 변경 사항
📁 /api/etf/theme/[themeSlug]
- 테마 슬러그(market-core, industry, strategy 등)를 기반으로 카테고리 ID 목록 조회
- 해당 ID에 대한 etfCategory 목록 반환
- "etc" 카테고리를 맨 마지막으로 정렬
- 응답 데이터: { displayName, categories : {id, name, fullPath } }

📁 /api/etf/category/[categoryId]
- 카테고리 ID에 따라 ETF 종목 리스트 조회
- 최신 거래일 기준 거래 데이터(종가, 거래량, 등락률) 포함
- keyword와 filter(name|code) 조건으로 검색 가능
- page, size 파라미터로 페이징 지원
- 응답에 해당 카테고리 fullPath 포함 (카테고리 상단 타이틀용)

💡 테스트
- /api/etf/theme/market-core 요청 시 해당 카테고리 목록 정상 반환
    ```
    {
        "displayName": "주식-시장대표",
        "categories": [
            {
                "id": 1,
                "name": "etc",
                "fullname": "주식-시장대표"
            }
        ]
    }
    ```
- /api/etf/category/13?keyword=tiger&filter=name&page=2&size=10 요청 시 필터링 및 페이징 정상 작동
    ```
    {
        "data": [
            {
                "issueCode": "0008E0",
                "issueName": "ACE 미국중심중소형제조업",
                "accTradeVolume": 6703,
                "tddClosePrice": "8805",
                "flucRate": "1.27"
            },
        "total": 21,
        "etfCategoryFullPath": "주식-업종섹터-업종테마"
    }
    ```
