### PR TITLE
Feat: 간편 비밀번호 바텀 시트 추가

### DIFF
--- a/app/(routes)/mypage/_components/delete-sheet.tsx
+++ b/app/(routes)/mypage/_components/delete-sheet.tsx
@@ -1,8 +1,11 @@
 'use client';
 
+import { useState } from 'react';
+import { toast } from 'react-hot-toast';
 import { AnimatePresence, motion } from 'framer-motion';
 import { X } from 'lucide-react';
 import Button from '@/components/button';
+import SecurePinModal from '@/components/secure-pin-modal';
 
 interface Props {
   visible: boolean;
@@ -21,6 +24,22 @@ const slideUp = {
 };
 
 const DeleteSheet = ({ visible, onClose, deleteAccount }: Props) => {
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const handleVerifyPin = async (pin: string) => {
+    try {
+      if (pin !== '123456') {
+        toast.error('비밀번호가 올바르지 않습니다.');
+        return false;
+      }
+      deleteAccount();
+      return true;
+    } catch (err) {
+      toast.error('서버 오류가 발생했습니다.');
+      return false;
+    }
+  };
+
   return (
     <AnimatePresence>
       {visible && (
@@ -64,9 +83,14 @@ const DeleteSheet = ({ visible, onClose, deleteAccount }: Props) => {
                     thin={false}
                     active={false}
                     className={'!rounded-xl'}
-                    onClick={() => deleteAccount()}
+                    onClick={() => setModalOpen(true)}
                   />
                 </div>
+                <SecurePinModal
+                  visible={modalOpen}
+                  onClose={() => setModalOpen(false)}
+                  onSubmit={handleVerifyPin}
+                />
               </div>
             </motion.div>
           </div>

--- a/app/(routes)/mypage/_components/delete-sheet.tsx
+++ b/app/(routes)/mypage/_components/delete-sheet.tsx
@@ -6,6 +6,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { X } from 'lucide-react';
 import Button from '@/components/button';
 import SecurePinModal from '@/components/secure-pin-modal';
+import { verifyPin } from '@/lib/api/my-page';
 
 interface Props {
   visible: boolean;
@@ -28,7 +29,8 @@ const DeleteSheet = ({ visible, onClose, deleteAccount }: Props) => {
 
   const handleVerifyPin = async (pin: string) => {
     try {
-      if (pin !== '123456') {
+      const res = await verifyPin(pin);
+      if (!res.success) {
         toast.error('비밀번호가 올바르지 않습니다.');
         return false;
       }

--- a/app/(routes)/mypage/_components/my-page-container.tsx
+++ b/app/(routes)/mypage/_components/my-page-container.tsx
@@ -55,7 +55,6 @@ export const MyPageContainer = ({ session }: Props) => {
   useEffect(() => {
     const fetchISA = async () => {
       const res = await fetchISAInfo();
-      console.log('res : ', res);
 
       if ('error' in res) {
         if (res.error === 'NOT_FOUND') {

--- a/app/(routes)/mypage/_components/ratio-chart.tsx
+++ b/app/(routes)/mypage/_components/ratio-chart.tsx
@@ -25,8 +25,6 @@ export default function EtfDetailRatioChart({
   data,
   onClickItem,
 }: EtfDetailRatioChartProps) {
-  // console.log('data : ', data);
-
   return (
     <div className='flex flex-col gap-5 w-full'>
       <div className='flex items-center justify-center w-full gap-4 flex-col'>

--- a/app/(routes)/mypage/account-connect/_components/account-connect-page-container.tsx
+++ b/app/(routes)/mypage/account-connect/_components/account-connect-page-container.tsx
@@ -77,8 +77,8 @@ const AccountConnectPageContainer = () => {
       });
 
       setTimeout(() => {
-        router.push('/mypage'); // 원하는 경로로 변경 가능
-      }, 2000);
+        router.push('/mypage');
+      }, 1000);
     } catch (err) {
       console.error('계좌 연결 오류', err);
       toast.error('잠시 후 다시 시도해주세요.', {
@@ -96,7 +96,7 @@ const AccountConnectPageContainer = () => {
   };
 
   return (
-    <div className='px-5 pt-21 pb-5 flex flex-col gap-8'>
+    <div className='px-5 pb-5 flex flex-col gap-8'>
       <div className='flex shadow rounded-lg p-5'>
         <ShieldCheck className='w-12 sm:w-10 sm:h-6 text-hana-green mr-2 relative top-0.5' />
         <div>

--- a/app/(routes)/mypage/account-connect/_components/bank-select-sheet.tsx
+++ b/app/(routes)/mypage/account-connect/_components/bank-select-sheet.tsx
@@ -48,17 +48,13 @@ const BankSelectSheet = ({
               variants={slideUp}
               transition={{ type: 'spring', stiffness: 300, damping: 30 }}
             >
-              <div className='flex justify-between items-center mb-4'>
-                <p className='text-lg font-semibold'>
-                  은행 혹은 증권사를 선택해 주세요
-                </p>
+              <div className='flex justify-end items-center mb-4 border-b border-b-gray-2'>
+                <div className='w-full inline-flex p-2 cursor-pointer text-xl font-semibold '>
+                  증권사
+                </div>
                 <button onClick={onClose}>
-                  <X className='w-6 h-6' />
+                  <X className='w-6 h-6 mb-8' />
                 </button>
-              </div>
-
-              <div className='w-full inline-flex p-2 mb-6 cursor-pointer text-xl font-semibold border-b border-b-gray-2'>
-                증권사
               </div>
 
               <div className='grid gap-4 custom-grid'>

--- a/app/(routes)/mypage/edit-profile/_components/edit-profile-container.tsx
+++ b/app/(routes)/mypage/edit-profile/_components/edit-profile-container.tsx
@@ -23,6 +23,7 @@ export const EditProfileContainer = () => {
     { target: '자택 정보', path: 'home' },
     { target: '이메일', path: 'email' },
     { target: '비밀번호', path: 'password' },
+    { target: '간편비밀번호', path: 'pin' },
   ];
 
   return (

--- a/app/(routes)/mypage/edit-profile/pin/_components/edit-pin-container.tsx
+++ b/app/(routes)/mypage/edit-profile/pin/_components/edit-pin-container.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { FormData } from '@/app/(routes)/(auth)/register/_components/register-form';
+import { useHeader } from '@/context/header-context';
+import Button from '@/components/button';
+import CustomInput from '@/components/input';
+import Input from '@/components/input';
+import { validateField } from '@/lib/utils';
+import { submitUserUpdate } from '../../utils';
+
+interface PinData {
+  oldPin: string;
+  newPin: string;
+}
+
+interface ValidationErrors {
+  oldPin: boolean;
+  newPin?: boolean;
+}
+
+export const EditPinContainer = () => {
+  const { setHeader } = useHeader();
+
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setHeader('내 정보 수정하기', '전화번호 수정');
+  }, []);
+
+  const [pinData, setPinData] = useState<PinData>({
+    oldPin: '',
+    newPin: '',
+  });
+  useEffect(() => {
+    console.log('pinData : ', pinData);
+  }, [pinData]);
+
+  useEffect(() => {
+    setHeader('내 정보 수정하기', '전화번호 수정');
+  }, []);
+
+  const [validationErrors, setValidationErrors] = useState<ValidationErrors>({
+    oldPin: true,
+    newPin: true,
+  });
+
+  const handleInputChange = (field: keyof PinData, value: string) => {
+    const raw = value.replace(/\D/g, '').slice(0, 6);
+
+    setPinData((prev) => ({ ...prev, [field]: raw }));
+
+    setValidationErrors((prev) => ({
+      ...prev,
+      [field]: !(raw.length === 6 && validateField(field, raw, pinData)),
+    }));
+  };
+
+  const submitData = async () => {
+    const data = { oldPinCode: pinData.oldPin, pinCode: pinData.newPin };
+    setLoading(true);
+    await submitUserUpdate({
+      data: data,
+      onSuccess: () => router.back(),
+      onFinally: () => setLoading(false),
+    });
+  };
+
+  return (
+    <div className='w-full pt-8 pb-10 px-7 flex flex-col gap-5'>
+      <h1 className='text-xl font-semibold'>간변비밀번호 변경</h1>
+      <div className='flex flex-col gap-4'>
+        <div className='flex flex-col gap-2'>
+          <label>이전 비밀번호</label>
+          <CustomInput
+            type='password'
+            thin={true}
+            placeholder=''
+            value={pinData.oldPin}
+            onChange={(val) => handleInputChange('oldPin', val)}
+          />
+        </div>
+
+        <div className='flex flex-col gap-2'>
+          <label>새로운 비밀번호</label>
+          <CustomInput
+            type='password'
+            thin={true}
+            placeholder=''
+            value={pinData.newPin}
+            onChange={(val) => handleInputChange('newPin', val)}
+          />
+        </div>
+      </div>
+      <Button
+        text={'비밀번호 변경'}
+        thin={false}
+        active={!validationErrors.oldPin && !validationErrors.newPin}
+        onClick={submitData}
+        disabled={validationErrors.oldPin || validationErrors.newPin}
+      />
+    </div>
+  );
+};
+export default EditPinContainer;

--- a/app/(routes)/mypage/edit-profile/pin/page.tsx
+++ b/app/(routes)/mypage/edit-profile/pin/page.tsx
@@ -1,0 +1,6 @@
+import EditPinContainer from './_components/edit-pin-container';
+
+const EditPinPage = () => {
+  return <EditPinContainer />;
+};
+export default EditPinPage;

--- a/app/(routes)/mypage/edit-profile/utils.tsx
+++ b/app/(routes)/mypage/edit-profile/utils.tsx
@@ -12,7 +12,6 @@ export const submitUserUpdate = async ({
   onFinally?: () => void;
 }) => {
   const res = await updateUser(data);
-  console.log('res : ', res);
 
   if (res.success) {
     toast.success('정보 수정이 완료되었습니다!', {

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -33,9 +33,7 @@ export const Button = ({
   }
   ${className}
 `.trim();
-  useEffect(() => {
-    console.log('disabled', disabled);
-  }, [disabled]);
+
   return (
     <button
       disabled={disabled}

--- a/components/header-bar/header-bar.tsx
+++ b/components/header-bar/header-bar.tsx
@@ -64,7 +64,6 @@ const HeaderBar = ({ title, subtitle, onMenuClick }: HeaderBarProps) => {
         <button onClick={onMenuClick} className='cursor-pointer'>
           <User />
         </button>
-        <div onClick={() => setModalOpen(true)}>간편비밀번호</div>
         <SecurePinModal
           visible={modalOpen}
           onClose={() => setModalOpen(false)}

--- a/components/header-bar/main-header-bar.tsx
+++ b/components/header-bar/main-header-bar.tsx
@@ -49,7 +49,6 @@ const MainHeader = ({ title, subtitle, onMenuClick }: MainHeaderProps) => {
         <button onClick={onMenuClick} className='cursor-pointer'>
           <User />
         </button>
-        <div onClick={() => setModalOpen(true)}>간편비밀번호</div>
         <SecurePinModal
           visible={modalOpen}
           onClose={() => setModalOpen(false)}

--- a/components/header-bar/page-header.tsx
+++ b/components/header-bar/page-header.tsx
@@ -1,8 +1,12 @@
 'use client';
 
 import { useState } from 'react';
+import { toast } from 'react-hot-toast';
 import { usePathname, useRouter } from 'next/navigation';
 import { useHeader } from '@/context/header-context';
+import SecurePinModal from '@/components/secure-pin-modal';
+import { verifyPin } from '@/lib/api/my-page';
+import { isPinVerified, setPinVerified } from '@/lib/session';
 import HeaderBar from './header-bar';
 import MainHeader from './main-header-bar';
 
@@ -13,16 +17,29 @@ export default function PageHeader() {
   const { title, subtitle } = useHeader();
   const router = useRouter();
 
-  // const [sidebarOpen, setSidebarOpen] = useState(false);
-  //
-  // const openSidebar = () => setSidebarOpen(true);
-  // const closeSidebar = () => setSidebarOpen(false);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const handleVerifyPin = async (pin: string) => {
+    const res = await verifyPin(pin);
+    console.log('res : ', res);
+    if (!res.success) {
+      toast.error('비밀번호가 올바르지 않습니다.');
+      return false;
+    }
+    setPinVerified();
+    setModalOpen(false);
+    router.push('/mypage');
+    return true;
+  };
 
   const userClick = () => {
-    if (pathname === '/mypage') {
-      return;
+    if (pathname === '/mypage') return;
+
+    if (isPinVerified()) {
+      router.push('/mypage');
+    } else {
+      setModalOpen(true);
     }
-    router.push('/mypage');
   };
 
   return (
@@ -50,6 +67,11 @@ export default function PageHeader() {
 
       {/* 사이드바 */}
       {/*<Sidebar isOpen={sidebarOpen} onClose={closeSidebar} />*/}
+      <SecurePinModal
+        visible={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSubmit={handleVerifyPin}
+      />
     </div>
   );
 }

--- a/components/secure-pin-modal.tsx
+++ b/components/secure-pin-modal.tsx
@@ -32,10 +32,6 @@ export default function PinCodeSheet({ visible, onClose, onSubmit }: Props) {
   const handleDelete = () => setPin((prev) => prev.slice(0, -1));
   const handleReset = () => setPin('');
 
-  if (pin.length === 6) {
-    setTimeout(() => onSubmit(pin), 150);
-  }
-
   const generateShuffledDigits = (): string[] => {
     const nums = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
     for (let i = nums.length - 1; i > 0; i--) {

--- a/components/secure-pin-modal.tsx
+++ b/components/secure-pin-modal.tsx
@@ -81,7 +81,7 @@ export default function PinCodeSheet({ visible, onClose, onSubmit }: Props) {
           {/* Bottom Sheet */}
           <div className='fixed bottom-0 left-0 right-0 z-60 flex justify-center '>
             <motion.div
-              className='w-full max-w-[768px] bg-white h-[90vh] px-6 pt-8 pb-10 overflow-y-auto rounded-2xl'
+              className='w-full max-w-[768px] bg-white h-[60vh] px-6 pt-8 pb-10 rounded-t-2xl'
               initial='hidden'
               animate='visible'
               exit='hidden'
@@ -126,7 +126,7 @@ export default function PinCodeSheet({ visible, onClose, onSubmit }: Props) {
                 ))}
               </div>
 
-              {/* 마지막 줄: 전체삭제 / 4 / ⌫ */}
+              {/* 마지막 줄 */}
               <div className='grid grid-cols-3 gap-3'>
                 <button
                   onClick={handleReset}

--- a/components/secure-pin-modal.tsx
+++ b/components/secure-pin-modal.tsx
@@ -81,7 +81,7 @@ export default function PinCodeSheet({ visible, onClose, onSubmit }: Props) {
           {/* Bottom Sheet */}
           <div className='fixed bottom-0 left-0 right-0 z-60 flex justify-center '>
             <motion.div
-              className='w-full max-w-[768px] bg-white h-[60vh] px-6 pt-8 pb-10 rounded-t-2xl'
+              className='w-full max-w-[768px] bg-white h-[70vh] px-6 pt-8 pb-10 rounded-t-2xl'
               initial='hidden'
               animate='visible'
               exit='hidden'

--- a/components/secure-pin-modal.tsx
+++ b/components/secure-pin-modal.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { X } from 'lucide-react';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  onSubmit: (pin: string) => Promise<boolean>;
+}
+
+const backdrop = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1 },
+};
+
+const slideUp = {
+  hidden: { y: '100%' },
+  visible: { y: 0 },
+};
+
+export default function PinCodeSheet({ visible, onClose, onSubmit }: Props) {
+  const [pin, setPin] = useState('');
+  const [digits, setDigits] = useState<string[]>([]);
+  const [isVerifying, setIsVerifying] = useState(false);
+
+  const handleDigit = (digit: string) => {
+    if (pin.length < 6) setPin((prev) => prev + digit);
+  };
+
+  const handleDelete = () => setPin((prev) => prev.slice(0, -1));
+  const handleReset = () => setPin('');
+
+  if (pin.length === 6) {
+    setTimeout(() => onSubmit(pin), 150);
+  }
+
+  const generateShuffledDigits = (): string[] => {
+    const nums = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+    for (let i = nums.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [nums[i], nums[j]] = [nums[j], nums[i]];
+    }
+    return nums;
+  };
+
+  useEffect(() => {
+    setDigits(generateShuffledDigits());
+  }, []);
+
+  useEffect(() => {
+    if (visible) {
+      setPin('');
+      setDigits(generateShuffledDigits());
+    }
+  }, [visible]);
+
+  useEffect(() => {
+    if (pin.length === 6 && !isVerifying) {
+      const verify = async () => {
+        setIsVerifying(true);
+        const success = await onSubmit(pin);
+        if (!success) setPin('');
+        setIsVerifying(false);
+      };
+      verify();
+    }
+  }, [pin]);
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <>
+          {/* Overlay */}
+          <motion.div
+            className='fixed inset-0 z-60 bg-black/40 max-w-[768px] mx-auto '
+            initial='hidden'
+            animate='visible'
+            exit='hidden'
+            variants={backdrop}
+            onClick={onClose}
+          />
+
+          {/* Bottom Sheet */}
+          <div className='fixed bottom-0 left-0 right-0 z-60 flex justify-center '>
+            <motion.div
+              className='w-full max-w-[768px] bg-white h-[90vh] px-6 pt-8 pb-10 overflow-y-auto rounded-2xl'
+              initial='hidden'
+              animate='visible'
+              exit='hidden'
+              variants={slideUp}
+              transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className='flex justify-end mb-4'>
+                <button onClick={onClose} className='cursor-pointer'>
+                  <X className='w-6 h-6' />
+                </button>
+              </div>
+
+              <div className='text-center mb-6'>
+                <h2 className='text-lg font-semibold'>
+                  비밀번호 6자리를 입력하세요
+                </h2>
+              </div>
+
+              {/* PIN 입력 상태 표시 */}
+              <div className='flex justify-center gap-3 mb-8'>
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className={`w-4 h-4 rounded-full border-2 ${
+                      i < pin.length ? 'bg-black' : 'border-gray-300'
+                    }`}
+                  />
+                ))}
+              </div>
+
+              {/* Keypad */}
+              <div className='grid grid-cols-3 gap-3 mb-3'>
+                {digits.slice(0, 9).map((digit, i) => (
+                  <button
+                    key={i}
+                    className='bg-primary text-white text-xl py-3 rounded-lg'
+                    onClick={() => handleDigit(digit)}
+                  >
+                    {digit}
+                  </button>
+                ))}
+              </div>
+
+              {/* 마지막 줄: 전체삭제 / 4 / ⌫ */}
+              <div className='grid grid-cols-3 gap-3'>
+                <button
+                  onClick={handleReset}
+                  className='text-sm text-gray-700 underline py-3'
+                >
+                  전체삭제
+                </button>
+
+                <button
+                  onClick={() => handleDigit(digits[9])}
+                  className='bg-primary text-white text-xl py-3 rounded-lg'
+                >
+                  {digits[9]}
+                </button>
+
+                <button
+                  onClick={handleDelete}
+                  className='text-xl text-gray-700 py-3'
+                >
+                  ⌫
+                </button>
+              </div>
+            </motion.div>
+          </div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/lib/api/my-page.ts
+++ b/lib/api/my-page.ts
@@ -60,10 +60,6 @@ export const updateUser = async (payload: UserUpdatePayload) => {
     }
 
     console.error('에러:', error.message);
-    console.log('{ success: false, error: error } : ', {
-      success: false,
-      error: error,
-    });
 
     return { success: false, error };
   }
@@ -92,6 +88,24 @@ export const leaveUser = async (password: string) => {
     body: JSON.stringify({ password }),
   });
 
+  if (!res.ok) {
+    const errorData = await res.json();
+    throw new Error(errorData.message || '탈퇴 요청 실패');
+  }
+
+  return res.json();
+};
+
+export const verifyPin = async (pin: string) => {
+  const data = { pinCode: pin };
+  const res = await fetch('/api/user/verify-pin', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+  console.log('verifyPin res : ', res);
   if (!res.ok) {
     const errorData = await res.json();
     throw new Error(errorData.message || '탈퇴 요청 실패');

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -1,0 +1,17 @@
+const PIN_VERIFY_KEY = 'pin-verified';
+
+export const setPinVerified = () => {
+  sessionStorage.setItem(PIN_VERIFY_KEY, Date.now().toString());
+};
+
+export const isPinVerified = (limitMinutes = 10): boolean => {
+  const stored = sessionStorage.getItem(PIN_VERIFY_KEY);
+  if (!stored) return false;
+
+  const verifiedAt = Number(stored);
+  return Date.now() - verifiedAt <= limitMinutes * 60 * 50; // 유효기간 : 10분
+};
+
+export const clearPinVerified = () => {
+  sessionStorage.removeItem(PIN_VERIFY_KEY);
+};

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -223,6 +223,9 @@ export const validateField = <T extends Record<string, any>>(
     case 'passwordConfirm':
       return value === formData.password && value.length > 0;
 
+    case 'pinCode':
+      return value.length === 6;
+
     default:
       return true;
   }


### PR DESCRIPTION
## 📌 연관된 이슈 번호

- closes #61 

## 🌱 주요 변경 사항

- 핀코드(간편비밀번호) 바텀 시트 추가
- 계좌 삭제 시 핀 코드 바텀 시트 검사 추가
- 마이페이지 진입 시 핀 코드 검사
  - 성공 시 10분 동안 세션 유지를 통해 추가 검사 방지
- 회원가입 시 핀 코드 입력 추가
- 회원정보 수정 핀 코드 추가

## 📸 스크린샷 (선택)

| 기능 | 스크린샷               |
| ---- | ---------------------- |
| 바텀 시트 프레이머 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/dd42f215-4aa7-489d-8b02-2aa6a7829181" /> |
| 수정 정보 리스트 - 핀 추가 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/490a5267-bd85-4a33-bceb-a896cd22f43b" /> |
| 핀 코드 수정 페이지 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/6878cdca-7a89-435d-8295-e00ccda91758" /> |
| 마이페이지 진입 시 프레이머 표시 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/9ecb954f-537c-4945-83b7-eee40e23159a" /> |
| 프레이머 - 비밀번호 불일치 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/42113ece-c363-459a-974d-190741e14aa2" /> |
| 회원가입 - 간편비밀번호 입력 추가 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/7f53341f-2173-479e-ae12-62cdd28c23f1"/> |
