### PR TITLE
Fix: 핀코드 프레이머 높이 수정 (#77)

### DIFF
--- a/app/(routes)/mypage/edit-profile/pin/_components/edit-pin-container.tsx
+++ b/app/(routes)/mypage/edit-profile/pin/_components/edit-pin-container.tsx
@@ -70,7 +70,7 @@ export const EditPinContainer = () => {
 
   return (
     <div className='w-full pt-8 pb-10 px-7 flex flex-col gap-5'>
-      <h1 className='text-xl font-semibold'>간변비밀번호 변경</h1>
+      <h1 className='text-xl font-semibold'>간편 비밀번호 변경</h1>
       <div className='flex flex-col gap-4'>
         <div className='flex flex-col gap-2'>
           <label>이전 비밀번호</label>

--- a/components/bottom-bar/index.tsx
+++ b/components/bottom-bar/index.tsx
@@ -28,7 +28,7 @@ export const BottomBar = () => {
       mx-auto max-w-[768px] w-full
       flex justify-around space-x-8 items-center
       border-t-[1.5px] border-t-gray-2 bg-white
-      z-52
+      z-49
       '
     >
       {items.map(({ to, text, icon: Icon }) => {

--- a/components/header-bar/header-bar.tsx
+++ b/components/header-bar/header-bar.tsx
@@ -7,7 +7,6 @@ import { useHeader } from '@/context/header-context';
 import BackIcon from '@/public/images/back-icon';
 import User from '@/public/images/common/user.svg';
 import { HeaderBarProps } from '@/types/components';
-import SecurePinModal from '@/components/secure-pin-modal';
 
 const HeaderBar = ({ title, subtitle, onMenuClick }: HeaderBarProps) => {
   const router = useRouter();
@@ -64,11 +63,6 @@ const HeaderBar = ({ title, subtitle, onMenuClick }: HeaderBarProps) => {
         <button onClick={onMenuClick} className='cursor-pointer'>
           <User />
         </button>
-        <SecurePinModal
-          visible={modalOpen}
-          onClose={() => setModalOpen(false)}
-          onSubmit={handleVerifyPin}
-        />
       </div>
     </div>
   );

--- a/components/header-bar/main-header-bar.tsx
+++ b/components/header-bar/main-header-bar.tsx
@@ -7,7 +7,6 @@ import { useRouter } from 'next/navigation';
 import User from '@/public/images/common/user.svg';
 import MenuIcon from '@/public/images/menu-icon';
 import { MainHeaderProps } from '@/types/components';
-import SecurePinModal from '@/components/secure-pin-modal';
 
 const MainHeader = ({ title, subtitle, onMenuClick }: MainHeaderProps) => {
   const [modalOpen, setModalOpen] = useState(false);
@@ -49,11 +48,6 @@ const MainHeader = ({ title, subtitle, onMenuClick }: MainHeaderProps) => {
         <button onClick={onMenuClick} className='cursor-pointer'>
           <User />
         </button>
-        <SecurePinModal
-          visible={modalOpen}
-          onClose={() => setModalOpen(false)}
-          onSubmit={handleVerifyPin}
-        />
       </div>
     </div>
   );

--- a/components/header-bar/page-header.tsx
+++ b/components/header-bar/page-header.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { usePathname, useRouter } from 'next/navigation';
 import { useHeader } from '@/context/header-context';
-import ModalWrapper from '@/utils/modal';
 import SecurePinModal from '@/components/secure-pin-modal';
 import { verifyPin } from '@/lib/api/my-page';
 import { isPinVerified, setPinVerified } from '@/lib/session';

--- a/components/header-bar/page-header.tsx
+++ b/components/header-bar/page-header.tsx
@@ -27,8 +27,10 @@ export default function PageHeader() {
       return false;
     }
     setPinVerified();
-    setModalOpen(false);
-    router.push('/mypage');
+    setTimeout(() => {
+      setModalOpen(false);
+      router.push('/mypage');
+    }, 300);
     return true;
   };
 

--- a/components/header-bar/page-header.tsx
+++ b/components/header-bar/page-header.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { usePathname, useRouter } from 'next/navigation';
 import { useHeader } from '@/context/header-context';
+import ModalWrapper from '@/utils/modal';
 import SecurePinModal from '@/components/secure-pin-modal';
 import { verifyPin } from '@/lib/api/my-page';
 import { isPinVerified, setPinVerified } from '@/lib/session';

--- a/components/secure-pin-modal.tsx
+++ b/components/secure-pin-modal.tsx
@@ -81,7 +81,7 @@ export default function PinCodeSheet({ visible, onClose, onSubmit }: Props) {
           {/* Bottom Sheet */}
           <div className='fixed bottom-0 left-0 right-0 z-60 flex justify-center '>
             <motion.div
-              className='w-full max-w-[768px] bg-white h-[70vh] px-6 pt-8 pb-10 rounded-t-2xl'
+              className='w-full max-w-[768px] bg-white min-h-[66dvh] max-h-[calc(100dvh-80px)] px-6 pt-8 rounded-t-2xl'
               initial='hidden'
               animate='visible'
               exit='hidden'

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap  text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap  text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-100 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
@@ -48,7 +48,7 @@ function Button({
 
   return (
     <Comp
-      data-slot="button"
+      data-slot='button'
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />


### PR DESCRIPTION
## 📌 연관된 이슈 번호

- closes #77

## 🌱 주요 변경 사항

- 웹 뷰에서 바텀바에 핀코드 입력 프레이머가 가려지는 현상 해결
- bottom-bar z-index : 52 -> 49

## 📸 스크린샷 (선택)

| 기능 | 스크린샷               |
| ---- | ---------------------- |
| 모바일 뷰 | <img width="329" alt="image" src="https://github.com/user-attachments/assets/a1870a46-c167-48d3-8922-71eeaf8d3fd7" /> |
| 웹 뷰 | <img width="329" alt="image" src="https://github.com/user-attachments/assets/25eb4bde-9c5b-43a7-bf92-2459d002968a"/> |