### PR TITLE
feat: 퀴즈 api,캘린더 조회 (#79)

### DIFF
--- a/app/api/quiz/calendar/route.ts
+++ b/app/api/quiz/calendar/route.ts
@@ -1,0 +1,34 @@
+import { getServerSession } from 'next-auth';
+import { NextResponse } from 'next/server';
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+import { authOptions } from '@/lib/auth-options';
+import { prisma } from '@/lib/prisma';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+
+  const userId = BigInt(session.user.id);
+
+  const records = await prisma.quizCalendar.findMany({
+    where: {
+      userId,
+    },
+    select: {
+      solvedDate: true,
+    },
+  });
+
+  const solvedDates = records.map((r) =>
+    dayjs.utc(r.solvedDate).tz('Asia/Seoul').format('YYYY-MM-DD')
+  );
+
+  return NextResponse.json({ solvedDates });
+}

--- a/app/api/quiz/question/route.ts
+++ b/app/api/quiz/question/route.ts
@@ -1,0 +1,88 @@
+import { getServerSession } from 'next-auth';
+import { NextResponse } from 'next/server';
+import { authOptions } from '@/lib/auth-options';
+import { prisma } from '@/lib/prisma';
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: BigInt(session.user.id) },
+  });
+
+  if (!user) {
+    return NextResponse.json({ message: 'User not found' }, { status: 404 });
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const existingCalendar = await prisma.quizCalendar.findUnique({
+    where: {
+      userId_solvedDate: {
+        userId: user.id,
+        solvedDate: today,
+      },
+    },
+  });
+
+  const totalCount = await prisma.question.count({
+    where: {
+      selections: {
+        some: {},
+      },
+    },
+  });
+
+  if (totalCount === 0) {
+    return NextResponse.json(
+      { message: 'No questions available' },
+      { status: 404 }
+    );
+  }
+
+  //매일 랜덤값-같은 날, 같은 사용자에게 같은 퀴즈 유지(즉 하루에 한번 변하는 랜덤퀴즈)
+  const seed = today.getTime() + Number(user.id); //날짜+사용자 기준으로 랜덤
+  const seededIndex = seed % totalCount;
+
+  const question = await prisma.question.findFirst({
+    where: {
+      selections: {
+        some: {},
+      },
+    },
+    skip: seededIndex,
+    include: {
+      selections: true,
+    },
+  });
+
+  if (!question) {
+    return NextResponse.json({ message: 'No question found' }, { status: 404 });
+  }
+
+  if (!existingCalendar) {
+    await prisma.quizCalendar.create({
+      data: {
+        userId: user.id,
+        solvedDate: today,
+      },
+    });
+  }
+
+  return NextResponse.json({
+    question: {
+      ...question,
+      id: question.id.toString(),
+      selections: question.selections.map((s) => ({
+        id: s.id.toString(),
+        questionId: s.questionId.toString(),
+        content: s.content,
+      })),
+    },
+    alreadySolved: !!existingCalendar,
+  });
+}

--- a/app/api/quiz/question/submit/route.ts
+++ b/app/api/quiz/question/submit/route.ts
@@ -1,0 +1,62 @@
+import { getServerSession } from 'next-auth';
+import { NextResponse } from 'next/server';
+import { authOptions } from '@/lib/auth-options';
+import { prisma } from '@/lib/prisma';
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+
+  const userId = BigInt(session.user.id);
+  const { questionId, selectedId } = await req.json();
+
+  const correct = await prisma.selection.findFirst({
+    where: {
+      questionId: BigInt(questionId),
+      answerFlag: true,
+    },
+  });
+
+  if (!correct) {
+    return NextResponse.json(
+      { message: 'Correct answer not found' },
+      { status: 404 }
+    );
+  }
+
+  const isCorrect = correct.id.toString() === selectedId.toString();
+
+  //KST 기준으로 해야함
+  const now = new Date();
+  const kstNow = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+  const kstDateOnly = new Date(
+    kstNow.getFullYear(),
+    kstNow.getMonth(),
+    kstNow.getDate()
+  );
+
+  await prisma.quizCalendar.upsert({
+    where: {
+      userId_solvedDate: {
+        userId,
+        solvedDate: kstDateOnly,
+      },
+    },
+    update: {},
+    create: {
+      userId,
+      solvedDate: kstDateOnly,
+    },
+  });
+
+  console.log('QUIZ 저장:', {
+    userId: userId.toString(),
+    date: kstDateOnly.toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' }),
+  });
+  return NextResponse.json({
+    isCorrect,
+    correctAnswerId: correct.id.toString(),
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "dayjs": "^1.11.13",
         "framer-motion": "^12.18.1",
         "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.514.0",
@@ -5955,6 +5956,12 @@
       "version": "4.1.0-0",
       "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
       "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "dayjs": "^1.11.13",
     "framer-motion": "^12.18.1",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.514.0",


### PR DESCRIPTION
## 📌 연관된 이슈 번호

- closes #79

## 🌱 주요 변경 사항

`1. GET /api/quiz/question
`	
• 사용자에게 매일 1개의 랜덤 퀴즈 제공
	• 같은 날에는 동일한 퀴즈를 다시 제공
	• 퀴즈를 처음 요청한 경우 quiz_calendar 테이블에 solved_date 기록
	• answerFlag는 응답에서 제외

`2. POST /api/quiz/question/submit
`	
• 사용자의 선택지 정답 여부 확인
	• quiz_calendar에 오늘 날짜 기록 (정답/오답 관계없이)
	• KST 기준 자정으로 날짜 처리 (UTC 저장 대비)

`3. GET /api/quiz/calendar
`	
• 사용자가 푼 날짜 목록 조회
	• YYYY-MM-DD 형식으로 변환하여 응답 (KST 기준)


## 🗂 디렉토리/파일 구조
```
/api/quiz/
├── question/
│   ├── route.ts        // GET: 오늘의 퀴즈 제공
│   └── submit/route.ts // POST: 정답 제출 및 기록
└── calendar/route.ts   // GET: 푼 날짜 리스트
```