### PR TITLE
Fix: etf 카테고리 api 수정

### DIFF
--- a/app/(routes)/etf/_components/data/etf-category-url-map.ts
+++ b/app/(routes)/etf/_components/data/etf-category-url-map.ts
@@ -24,7 +24,7 @@ export const idToCategoryUrl: Record<number, string> = {
   23: 'market-cap?sub=대형주',
   24: 'market-cap?sub=중형주',
   25: 'mixed-assets?sub=etc',
-  26: 'mixed-assets?sub=주식+채권',
+  26: 'mixed-assets?sub=주식%2B채권',
 };
 
 /*

--- a/app/api/etf/category/[categoryId]/route.ts
+++ b/app/api/etf/category/[categoryId]/route.ts
@@ -98,7 +98,7 @@ export async function GET(req: NextRequest) {
         ? Number(etf.tradings[0]?.accTradeVolume)
         : 0,
       tddClosePrice: etf.tradings[0]?.tddClosePrice ?? 0,
-      flucRate: etf.tradings[0]?.flucRate ?? 0,
+      flucRate: etf.tradings[0]?.flucRate ?? '0',
     }));
 
     // 카테고리 테마 보여주기 위해 fullPath 반환, - 기준으로 가장 끝 요소 추출해서 사용


### PR DESCRIPTION
## 📌 연관된 이슈 번호

- closes #136 

## 🌱 주요 변경 사항

- 추천 카테고리 중 "+" 가 포함되었을 경우 정상적으로 요청하지 못하는 문제 해결
- etf 정보 중 flucRate 필드의 타입이 string 일 경우와 number 일 경우가 달라 에러가 발생하던 문제 해결 -> api 수정

## 📸 스크린샷 (선택)

| 기능 | 스크린샷               |
| ---- | ---------------------- |
| 카테고리 이동 - 기존 | <img width="458" alt="image" src="https://github.com/user-attachments/assets/b88220be-c462-4fd1-8850-4f7801a10a79" /> |
| 카테고리 이동 - 변경 | <img width="477" alt="image" src="https://github.com/user-attachments/assets/a4586db3-d95d-4341-aca9-14502f44dbc8" /> |



