### PR TITLE
Feat: 챌린지 보상 수령 API 및 출석 진행도 로직 구현

### DIFF
--- a/app/api/challenge/claim/route.ts
+++ b/app/api/challenge/claim/route.ts
@@ -1,0 +1,157 @@
+import { getServerSession } from 'next-auth';
+import { NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { authOptions } from '@/lib/auth-options';
+import { prisma } from '@/lib/prisma';
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+
+  const userId = BigInt(session.user.id);
+  const { challengeId } = await req.json();
+
+  // 챌린지 정보 불러오기 (유형 포함)
+  const challenge = await prisma.challenge.findUniqueOrThrow({
+    where: { id: challengeId },
+    include: { etf: true },
+  });
+  //console.log('Challenge fetched:', challenge.id, challenge.challengeType);
+
+  // 수령 여부 확인
+  const existingClaim = await prisma.userChallengeClaim.findFirst({
+    where: {
+      userId,
+      challengeId,
+    },
+  });
+  // console.log('Existing claim:', !!existingClaim);
+
+  //이미 받았음
+  if (existingClaim) {
+    return NextResponse.json({ message: 'Already claimed' }, { status: 400 });
+  }
+
+  // 보상 수령일: 오늘 자정 (UTC)
+  const now = new Date();
+  const utcMidnight = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  );
+
+  const latestPrice = await prisma.etfDailyTrading.findFirst({
+    where: { etfId: challenge.etfId },
+    orderBy: { baseDate: 'desc' },
+    select: { tddClosePrice: true },
+  });
+
+  if (latestPrice?.tddClosePrice) {
+    //const expectedCost = challenge.quantity.mul(latestPrice.tddClosePrice)
+    //console.log('✅ 검증용 expected avgCost:', expectedCost.toFixed(2))
+  }
+
+  //트랜잭션 처리
+  await prisma.$transaction(async (tx) => {
+    // 1. 수령 기록 저장
+    await tx.userChallengeClaim.create({
+      data: {
+        userId,
+        challengeId,
+        claimDate: utcMidnight,
+      },
+    });
+    //console.log(' 📍Claim record created for user:', userId.toString(), 'challenge:', challengeId.toString());
+
+    // 2. 진행도 초기화
+    if (challenge.challengeType !== 'ONCE') {
+      await tx.userChallengeProgress.updateMany({
+        where: { userId, challengeId },
+        data: { progressVal: 0 },
+      });
+      //console.log('Progress reset for user:', userId.toString(), 'challenge:', challengeId.toString());
+    }
+
+    // 3. 보상 지급 처리
+    const user = await tx.user.findUniqueOrThrow({
+      where: { id: userId },
+      include: { isaAccount: true },
+    });
+    const isaAccountId = user.isaAccount?.id;
+    //console.log('📍User fetched with ISA account:', isaAccountId?.toString());
+
+    if (!isaAccountId) throw new Error('ISA 계좌가 없습니다');
+
+    // ETF daily trading 에서 가장 최신 종가
+    const latestTrading = await tx.etfDailyTrading.findFirst({
+      where: { etfId: challenge.etfId },
+      orderBy: { baseDate: 'desc' },
+    });
+    //console.log("최신종가 : ", latestTrading);
+
+    if (!latestTrading?.tddClosePrice) {
+      throw new Error('최신 종가 정보를 찾을 수 없습니다');
+    }
+
+    const transaction = await tx.eTFTransaction.create({
+      data: {
+        isaAccountId,
+        etfId: challenge.etfId,
+        quantity: challenge.quantity,
+        transactionType: 'CHALLENGE_REWARD',
+        price: latestTrading.tddClosePrice,
+        transactionAt: now,
+      },
+    });
+    //console.log('Transaction created:', transaction);
+
+    //최신종가 * 지급수량
+    const existingHolding = await tx.eTFHolding.findUnique({
+      where: {
+        isaAccountId_etfId: {
+          isaAccountId,
+          etfId: challenge.etfId,
+        },
+      },
+    });
+
+    let avgCost: Prisma.Decimal;
+
+    if (existingHolding) {
+      const totalQuantity = existingHolding.quantity.add(challenge.quantity);
+      const totalCost = existingHolding.avgCost
+        .mul(existingHolding.quantity)
+        .add(challenge.quantity.mul(latestTrading.tddClosePrice));
+      avgCost = totalCost.div(totalQuantity);
+      //console.log('📌 Adjusted avgCost for existing holding:', avgCost.toFixed(2))
+    } else {
+      avgCost = latestTrading.tddClosePrice;
+      //console.log('📌 New holding avgCost (latest price):', avgCost.toFixed(2))
+    }
+
+    await tx.eTFHolding.upsert({
+      where: {
+        isaAccountId_etfId: {
+          isaAccountId,
+          etfId: challenge.etfId,
+        },
+      },
+      update: {
+        quantity: { increment: challenge.quantity },
+        avgCost: avgCost,
+        updatedAt: now,
+      },
+      create: {
+        isaAccountId,
+        etfId: challenge.etfId,
+        quantity: challenge.quantity,
+        avgCost: avgCost,
+        acquiredAt: now,
+        updatedAt: now,
+      },
+    });
+    //console.log('ETF holding updated or created');
+  });
+
+  return NextResponse.json({ message: 'Reward claimed successfully' });
+}

--- a/app/api/quiz/question/submit/route.ts
+++ b/app/api/quiz/question/submit/route.ts
@@ -66,6 +66,58 @@ export async function POST(req: Request) {
     },
   });
 
+  // DAILY 챌린지 수령 처리 (QUIZ_DAILY)
+  const quizChallenge = await prisma.challenge.findUnique({
+    where: { code: 'QUIZ_DAILY' },
+  });
+
+  // STREAK 챌린지 진행도 증가 (ATTEND_7DAY)
+  const streakChallenge = await prisma.challenge.findUnique({
+    where: { code: 'ATTEND_7DAY' },
+  });
+
+  if (streakChallenge) {
+    await prisma.userChallengeProgress.upsert({
+      where: {
+        userId_challengeId: {
+          userId,
+          challengeId: streakChallenge.id,
+        },
+      },
+      create: {
+        userId,
+        challengeId: streakChallenge.id,
+        progressVal: 1,
+      },
+      update: {
+        progressVal: {
+          increment: 1,
+        },
+      },
+    });
+  }
+
+  if (quizChallenge) {
+    await prisma.userChallengeProgress.upsert({
+      where: {
+        userId_challengeId: {
+          userId,
+          challengeId: quizChallenge.id,
+        },
+      },
+      create: {
+        userId,
+        challengeId: quizChallenge.id,
+        progressVal: 1,
+      },
+      update: {
+        progressVal: {
+          increment: 1,
+        },
+      },
+    });
+  }
+
   console.log('QUIZ 저장:', {
     userId: userId.toString(),
     solvedDate: solvedDate.toISOString(), // 항상 15:00:00Z 형식으로 저장됨


### PR DESCRIPTION
## 📌 연관된 이슈 번호

- closes #125

## 🌱 주요 변경 사항

### 1. submit/route.ts – 퀴즈 제출 시 출석 관련 챌린지 진행도 기록
	•	퀴즈 제출 시 quizCalendar에 KST 자정 기준 출석 기록을 upsert 처리하여 중복 방지.
	•	DAILY 챌린지(QUIZ_DAILY)와 STREAK 챌린지(ATTEND_7DAY) 모두 userChallengeProgress에 upsert + increment 방식으로 진행도 기록.
	•	매일 퀴즈를 푸는 것만으로도 자동으로 챌린지 진행도가 누적되도록 구현.
	•	정확한 출석 일시는 UTC 기준 자정(KST 기준 오전 9시) 으로 통일하여 처리.

### 2. claim/route.ts – 보상 수령 API 구현
	•	사용자가 수령 가능한 챌린지를 수동으로 “보상 받기” 버튼을 눌렀을 때 실행되는 API.
	•	userChallengeClaim에 claimDate(해당 챌린지 조건 달성 일자) 기준으로 중복 수령 방지.
	•	claim 발생 시 아래 로직 트랜잭션 처리:
	•	거래 이력 기록: eTFTransaction 테이블에 최신 종가로 기록
	•	ETF 보유량 반영: eTFHolding 테이블에 upsert
	•	기존 보유 중이면: 평균 단가(avgCost)를 보유 수량과 지급 수량의 가중 평균으로 계산
	•	보유 내역 없으면: 최신 종가로 avgCost 설정
	•	모든 보상 처리와 단가 계산은 Prisma.transaction 내에서 안전하게 처리.

## 🔎 검증 방법
	•	퀴즈 제출 API 테스트 후 userChallengeProgress에 두 개 챌린지 모두 진행도 1 증가 확인
	•	보상 수령 버튼 클릭 시:
	•	userChallengeClaim에 레코드 생성
	•	eTFTransaction에 거래 기록 생성 (최신 종가 반영)
	•	eTFHolding에 ETF 보유 수량 증가 및 평균 단가 계산 반영
	•	로그로 avgCost와 거래 정보가 정상 출력되는지 확인

## ⚠️ 주의 사항
	•	RDS 및 서버 시간은 UTC 기준으로 유지되며, 프론트에서는 항상 KST 기준으로 계산된 자정 값을 넘겨야 일관된 처리 가능.
	•	추후 ONCE 챌린지도 진행도 증가 및 수령 로직에서 예외 처리 필요 시 추가 고려 예정.