### PR TITLE
feat: 보상동의 api

### DIFF
--- a/app/api/user/reward-agree/route.ts
+++ b/app/api/user/reward-agree/route.ts
@@ -1,0 +1,44 @@
+import { getServerSession } from 'next-auth';
+import { NextResponse } from 'next/server';
+import { authOptions } from '@/lib/auth-options';
+import { prisma } from '@/lib/prisma';
+
+export async function PATCH(req: Request) {
+  try {
+    const session = await getServerSession(authOptions);
+    const userId = session?.user?.id;
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: '인증되지 않은 사용자입니다.' },
+        { status: 401 }
+      );
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: BigInt(userId) },
+    });
+
+    if (!user) {
+      return NextResponse.json(
+        { error: '해당 사용자를 찾을 수 없습니다.' },
+        { status: 404 }
+      );
+    }
+
+    await prisma.user.update({
+      where: { id: BigInt(userId) },
+      data: { rewardAgreed: true },
+    });
+
+    return NextResponse.json({ message: '보상 동의 완료' }, { status: 200 });
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(
+      { error: '알 수 없는 오류 발생' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## 📌 연관된 이슈 번호

- closes #166

## 🌱 주요 변경 사항

사용자가 보상 수령에 동의할 수 있도록 하는 API를 추가하였습니다. 세션에서 로그인된 사용자의 ID를 추출하여 rewardAgreed 값을 true로 업데이트합니다

- PATCH /api/reward-agree API 라우트 추가
- getServerSession(authOptions)을 통해 세션에서 사용자 ID 추출
- Prisma를 통해 해당 사용자의 rewardAgreed 필드 업데이트
- 예외 상황 처리: 로그인되지 않은 사용자 / 존재하지 않는 사용자 / 서버 에러


